### PR TITLE
Examples: add dom-editor - live DOM rewriting from English commands

### DIFF
--- a/examples/dom-editor/.gitignore
+++ b/examples/dom-editor/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.vite/

--- a/examples/dom-editor/README.md
+++ b/examples/dom-editor/README.md
@@ -1,0 +1,91 @@
+# DOM editor (browser)
+
+A real-life use case for needle-rs: a 22 MB tool-calling LLM that rewrites a
+live web page from plain-English commands, entirely in the browser. No server,
+no API key, no data leaving the tab.
+
+Type one command (`"make the title red"`, `"set the lede background to teal"`).
+The harness walks the current DOM, generates one tool per (element × action),
+narrows the list with the model's contrastive head, then asks the model to
+pick exactly one tool with its arguments filled in. The selected tool runs
+against the DOM. Type the next command. The page evolves one step at a time.
+
+## Why this is interesting
+
+Most tool-calling demos give the model a hand-crafted, static list of tools.
+This one **generates the tools fresh every turn from the current page state**,
+which turns the targeting problem into the thing Needle is best at:
+"given English + a list of clearly-named tools, pick one."
+
+The model never sees a CSS selector or an abstract schema slot like
+`property`. Each tool's *name* encodes which element it targets
+(`set_title_color`, `set_lede_background`); the element itself lives in the
+tool's closure on the JS side. Adding or removing DOM nodes in one command
+automatically reshapes the tool list for the next.
+
+## Pipeline
+
+```
+command → walk the DOM → generate ~N candidate tools
+                          (one per interesting element × action)
+        → engine.retrieve_tools()  ← stage 1: contrastive narrowing to top-K
+        → engine.run()             ← stage 2: route to one tool, fill its args
+        → execute against the DOM
+```
+
+Both stages run in a Web Worker (`src/worker.ts`) so the main thread stays
+interactive while the WASM engine does its multi-second `run()`.
+
+Regions of the page marked `data-no-edit` (the prompt input, the activity
+log, the load panel, the limitations notice) are filtered out of the DOM
+walk — the model can't wipe what someone is typing or scramble its own log.
+
+## Quickstart
+
+```bash
+cd examples/dom-editor
+npm install
+npm run dev
+```
+
+Open the printed URL, click **Load model** (22 MB, cached by the browser after
+the first run), then chain commands. The right-hand panel shows every tool
+generated for the current command, with the top-K candidates highlighted and
+the picked one marked in green.
+
+The model and runtime are pulled from the published `needle-rs` npm package,
+so this example builds standalone without a local Rust toolchain.
+
+## Layout
+
+```
+index.html        — UI (prompt, log, tools panel, limitations notice)
+src/
+  main.ts         — UI wiring and rendering
+  harness.ts      — two-stage dispatch (retrieve → route → execute)
+  tools.ts        — DOM walker + per-element tool generator
+  model.ts        — postMessage client for the engine worker
+  worker.ts       — owns the NeedleWasm engine; streams progress + results
+  style.css
+```
+
+## Design notes worth reading the source for
+
+- `tools.ts` — how DOM elements are turned into model-friendly labels
+  (`#app-title` → `title`, not `app_title`), why every tool name carries its
+  target, and why descriptions deliberately *omit* the element's text preview
+  (it dominated everything and the router couldn't discriminate between
+  color/background/text).
+- `harness.ts` — why the top-K is small (4) and what happens when the
+  contrastive head isn't available (a JS term-overlap fallback ranker, so we
+  don't degenerate to DOM order).
+- `tools.ts` color/text parameter shapes — anchoring schemas with realistic
+  examples (`"e.g. 'Welcome' or 'Hello world'"`) is the difference between
+  the model emitting a valid call and returning `[]`.
+
+## Caveats
+
+This is a 26M-parameter router. It is good at single, clear commands and bad
+at compound or ambiguous ones. The on-screen "Limitations" panel explains
+what the model can and can't do — the same caveats apply to any production
+use of needle-rs.

--- a/examples/dom-editor/index.html
+++ b/examples/dom-editor/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>needle-playground — local LLM rewrites the DOM</title>
+    <meta name="description" content="A 22 MB tool-calling LLM running entirely in your browser, manipulating the page in real time." />
+  </head>
+  <body>
+    <main id="app">
+      <header class="topbar">
+        <div class="brand">
+          <span class="logo">◆</span>
+          <h1 id="app-title">needle-playground</h1>
+          <span id="status-pill" class="pill" data-no-edit>model not loaded</span>
+        </div>
+        <a id="repo-link" href="https://github.com/geekgineer/needle-rs" target="_blank" rel="noopener" class="muted">needle-rs ↗</a>
+      </header>
+
+      <section id="load-panel" class="panel">
+        <p id="lede" class="lede">
+          A 26M-parameter tool-calling LLM runs entirely in this tab. Type one English command;
+          the model walks <strong>this whole page</strong>, generates tools for what it finds,
+          and changes one thing. Yes — the title, this paragraph, even the footer.
+        </p>
+        <button id="load-btn" class="primary" data-no-edit>Load model (22 MB, cached after first run)</button>
+        <div id="progress" class="progress hidden" data-no-edit>
+          <div class="progress-row"><span id="progress-label">Downloading…</span><span id="progress-bytes" class="mono">0 / 22 MB</span></div>
+          <div class="progress-bar"><div id="progress-fill"></div></div>
+        </div>
+      </section>
+
+      <section id="play-panel" class="panel hidden" data-no-edit>
+        <div class="prompt-row">
+          <input id="goal-input" type="text" placeholder="One command, e.g. 'make the title red'…" value="Make the title red" />
+          <button id="run-btn" class="primary">Run →</button>
+        </div>
+        <div class="examples" id="examples"></div>
+      </section>
+
+      <section class="log-section">
+        <div class="panel log-panel" data-no-edit>
+          <div class="panel-label">Steps</div>
+          <ol id="log" class="log"></ol>
+        </div>
+        <div class="panel tools-panel" data-no-edit>
+          <div class="panel-label">
+            Generated tools
+            <span id="tools-count" class="mono muted"></span>
+          </div>
+          <p id="tools-empty" class="muted small">Tools are generated from the current DOM on every run. Run a command to see the list.</p>
+          <ul id="tools-list" class="tools-list hidden"></ul>
+          <div class="tools-legend muted small">
+            <span><span class="dot dot-picked"></span> picked</span>
+            <span><span class="dot dot-selected"></span> top-K candidate</span>
+            <span><span class="dot dot-other"></span> generated, not selected</span>
+          </div>
+        </div>
+      </section>
+
+      <aside class="disclaimer panel" data-no-edit>
+        <div class="panel-label">Limitations</div>
+        <ul>
+          <li>This is a <strong>26M-parameter</strong> model — expect mistakes, ignored commands, and odd rewrites. It is a tech demo, not a reliable assistant.</li>
+          <li>Edits are limited to text and inline styles of elements visible in this tab. Anything marked <code>data-no-edit</code> is off-limits, and no changes persist after a refresh.</li>
+          <li>The model only sees the current DOM — it has no browsing, memory across runs, or knowledge of the world beyond what's on this page.</li>
+          <li>English prompts only. Runs entirely on your device's CPU/GPU, so latency depends on your hardware.</li>
+        </ul>
+      </aside>
+
+      <footer id="page-footer" class="footer muted">
+        <span>Two-stage pipeline · retrieve → route · <a href="https://huggingface.co/Abdalrahman/needle-rs-safetensors" target="_blank" rel="noopener">weights on HF</a></span>
+      </footer>
+    </main>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/dom-editor/package.json
+++ b/examples/dom-editor/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "needle-dom-editor-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.2",
+    "vite": "^8.0.12"
+  },
+  "dependencies": {
+    "needle-rs": "^0.1.0"
+  }
+}

--- a/examples/dom-editor/src/harness.ts
+++ b/examples/dom-editor/src/harness.ts
@@ -1,0 +1,179 @@
+// Two-stage dispatch pipeline.
+//
+//   command → generate tools from current DOM
+//           → contrastively narrow to top-K (model call 1)
+//           → route to one tool (model call 2)
+//           → execute
+//
+// Each user command kicks off the whole pipeline fresh, so the tool universe
+// reflects the *current* DOM. Elements added or removed by previous commands
+// reshape the next command's tool list automatically.
+
+import type { NeedleModel } from "./model";
+import { generateTools, toolsSchemaJson, type GeneratedTool, type ToolCall, type ToolResult } from "./tools";
+
+export type ToolSummary = { name: string; description: string };
+
+export type Step = {
+  call: ToolCall;
+  result: ToolResult;
+  rawModelOutput: string;
+  // Pipeline observability — useful to surface in the UI / log.
+  candidateCount: number;
+  selectedCount: number;
+  retrieveMs: number;
+  inferMs: number;
+  generated: ToolSummary[];
+  selectedNames: string[];
+};
+
+export type DispatchResult =
+  | { type: "step"; step: Step }
+  | { type: "error"; message: string; rawModelOutput?: string; generated?: ToolSummary[]; selectedNames?: string[] };
+
+// Keep this small. The Needle model overflows its context when given too many
+// tools with verbose schemas — when that happens it returns `[]` instead of
+// picking. Empirically, 4 works.
+const TOP_K = 4;
+
+// Stopwords stripped from queries/descriptions before ranking — they're noise
+// for term overlap and would otherwise let any tool with "the" or "a" score.
+const STOPWORDS = new Set([
+  "a", "an", "the", "to", "of", "in", "on", "at", "and", "or", "for",
+  "is", "are", "was", "were", "be", "make", "set", "change", "color",
+  "text", "with", "this", "that", "it", "do", "please",
+]);
+
+function tokens(s: string): string[] {
+  return s.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t && !STOPWORDS.has(t));
+}
+
+// JS-side fallback ranker. Scores each tool by counting query tokens that
+// appear in either the tool's *name* (split on underscores) or its
+// description. Names matter because the element label ("title", "footer",
+// "lede") lives there — descriptions often only carry the role word and
+// the element's literal text. Without name-scoring, "change the title to
+// Hello" finds no match and ties degenerate to DOM order.
+function rankByTermOverlap(
+  query: string,
+  tools: Array<{ name: string; description: string }>,
+  topK: number,
+): number[] {
+  const q = new Set(tokens(query));
+  const scored = tools.map((t, i) => {
+    const nameToks = tokens(t.name.replace(/_/g, " "));
+    const descToks = tokens(t.description);
+    let score = 0;
+    for (const tok of nameToks) if (q.has(tok)) score++;
+    for (const tok of descToks) if (q.has(tok)) score++;
+    return { i, score };
+  });
+  scored.sort((a, b) => b.score - a.score || a.i - b.i);
+  return scored.slice(0, topK).map((s) => s.i);
+}
+
+function parseToolCall(raw: string): ToolCall | null {
+  try {
+    const parsed = JSON.parse(raw);
+    const obj = Array.isArray(parsed) ? parsed[0] : parsed;
+    if (!obj || typeof obj.name !== "string") return null;
+    const args = obj.arguments && typeof obj.arguments === "object" ? obj.arguments : {};
+    return { name: obj.name, arguments: args as Record<string, unknown> };
+  } catch {
+    return null;
+  }
+}
+
+export async function dispatch(
+  model: NeedleModel,
+  root: HTMLElement,
+  command: string,
+): Promise<DispatchResult> {
+  const { tools } = generateTools(root);
+  const generated: ToolSummary[] = tools.map((t) => ({ name: t.name, description: t.description }));
+  if (tools.length === 0) {
+    return { type: "error", message: "no editable elements found on the page", generated };
+  }
+
+  // Stage 1: narrow the candidate set to top-K. Prefer the model's contrastive
+  // head if present; if the loaded weights don't include one, fall back to a
+  // JS term-overlap ranker so we don't end up just picking the first K tools
+  // in DOM order.
+  const t0 = performance.now();
+  let selected: GeneratedTool[];
+  if (tools.length <= TOP_K) {
+    selected = tools;
+  } else {
+    const descriptions = tools.map((t) => t.description);
+    let indices: number[] = [];
+    if (model.hasContrastiveHead()) {
+      const ranked = await model.retrieve(command, descriptions, TOP_K);
+      indices = ranked.map((r) => r.index);
+    }
+    if (indices.length === 0) {
+      indices = rankByTermOverlap(command, tools, TOP_K);
+    }
+    selected = indices.map((i) => tools[i]).filter((t): t is GeneratedTool => Boolean(t));
+  }
+  const retrieveMs = performance.now() - t0;
+
+  // Stage 2: routing. Hand the narrowed list to run() and let the model pick
+  // exactly one with its arguments filled in.
+  const t1 = performance.now();
+  const selectedNames = selected.map((t) => t.name);
+  let raw: string;
+  try {
+    raw = await model.infer(command, toolsSchemaJson(selected));
+  } catch (e) {
+    return { type: "error", message: `inference failed: ${(e as Error).message}`, generated, selectedNames };
+  }
+  const inferMs = performance.now() - t1;
+
+  const call = parseToolCall(raw);
+  if (!call) {
+    // Surface enough context to debug from a console paste. The model
+    // returning "[]" is the most common variant — usually a context overflow
+    // or a query the ranker couldn't match to anything sensible.
+    console.warn("[needle-playground] dispatch failure", {
+      command,
+      rawModelOutput: raw,
+      narrowedTools: selected.map((t) => ({ name: t.name, description: t.description })),
+    });
+    return {
+      type: "error",
+      message: raw.trim() === "[]"
+        ? "model returned no tool call (empty array) — see console for the 4 candidates it had to choose from"
+        : "could not parse model output — see console",
+      rawModelOutput: raw,
+      generated,
+      selectedNames,
+    };
+  }
+
+  const tool = selected.find((t) => t.name === call.name);
+  let result: ToolResult;
+  if (!tool) {
+    result = { ok: false, error: `unknown tool: ${call.name}` };
+  } else {
+    try {
+      result = tool.execute(call.arguments);
+    } catch (e) {
+      result = { ok: false, error: `exec failed: ${(e as Error).message}` };
+    }
+  }
+
+  return {
+    type: "step",
+    step: {
+      call,
+      result,
+      rawModelOutput: raw,
+      candidateCount: tools.length,
+      selectedCount: selected.length,
+      retrieveMs,
+      inferMs,
+      generated,
+      selectedNames,
+    },
+  };
+}

--- a/examples/dom-editor/src/main.ts
+++ b/examples/dom-editor/src/main.ts
@@ -1,0 +1,208 @@
+import "./style.css";
+import { NeedleModel, type LoadProgress } from "./model";
+import { dispatch, type Step, type ToolSummary } from "./harness";
+
+const $ = <T extends HTMLElement = HTMLElement>(id: string) =>
+  document.getElementById(id) as T;
+
+// Atomic commands — Needle is a single-turn router, so each command should be
+// expressable as one tool call.
+const EXAMPLES = [
+  "Make the title red",
+  "Change the title to Hello",
+  "Set the lede background to teal",
+  "Make the footer text yellow",
+  "Add a paragraph saying hello world",
+];
+
+const statusPill = $("status-pill");
+const loadBtn = $<HTMLButtonElement>("load-btn");
+const progressEl = $("progress");
+const progressLabel = $("progress-label");
+const progressBytes = $("progress-bytes");
+const progressFill = $("progress-fill");
+const playPanel = $("play-panel");
+const goalInput = $<HTMLInputElement>("goal-input");
+const runBtn = $<HTMLButtonElement>("run-btn");
+// The model edits the whole page. UI regions that should be off-limits (the
+// command input, the activity log) carry `data-no-edit` in index.html and
+// are filtered out by the DOM walker in tools.ts.
+const editableRoot = document.body;
+const log = $<HTMLOListElement>("log");
+const examplesEl = $("examples");
+const toolsList = $<HTMLUListElement>("tools-list");
+const toolsEmpty = $("tools-empty");
+const toolsCount = $("tools-count");
+
+let model: NeedleModel | null = null;
+
+function setStatus(state: "idle" | "loading" | "ready" | "running" | "error", text: string) {
+  statusPill.className = `pill ${state === "idle" ? "" : state}`;
+  statusPill.textContent = text;
+}
+
+function renderProgress(p: LoadProgress) {
+  progressEl.classList.remove("hidden");
+  const labels: Record<LoadProgress["stage"], string> = {
+    init: "Initializing WASM…",
+    weights: "Downloading weights…",
+    vocab: "Downloading vocab…",
+    engine: "Initializing engine…",
+    ready: "Ready",
+  };
+  progressLabel.textContent = labels[p.stage];
+  if (p.loadedBytes !== undefined && p.totalBytes) {
+    const mb = (n: number) => (n / 1024 / 1024).toFixed(1);
+    progressBytes.textContent = `${mb(p.loadedBytes)} / ${mb(p.totalBytes)} MB`;
+    progressFill.style.width = `${(p.loadedBytes / p.totalBytes) * 100}%`;
+  } else {
+    progressBytes.textContent = "";
+  }
+}
+
+function appendStep(command: string, step: Step) {
+  const li = document.createElement("li");
+
+  const cmdLine = document.createElement("div");
+  cmdLine.className = "meta";
+  cmdLine.textContent = `> ${command}`;
+
+  const callLine = document.createElement("div");
+  callLine.className = "call";
+  const toolName = document.createElement("span");
+  toolName.className = "tool-name";
+  toolName.textContent = step.call.name;
+  callLine.appendChild(toolName);
+  callLine.appendChild(document.createTextNode(`(${JSON.stringify(step.call.arguments)})`));
+
+  const resultLine = document.createElement("div");
+  resultLine.className = `result ${step.result.ok ? "ok" : "err"}`;
+  resultLine.textContent = step.result.ok ? `→ ${step.result.summary}` : `× ${step.result.error}`;
+
+  const timing = document.createElement("div");
+  timing.className = "meta";
+  timing.textContent =
+    `retrieve ${step.retrieveMs.toFixed(0)} ms · infer ${step.inferMs.toFixed(0)} ms · ` +
+    `${step.selectedCount}/${step.candidateCount} tools`;
+
+  li.appendChild(cmdLine);
+  li.appendChild(callLine);
+  li.appendChild(resultLine);
+  li.appendChild(timing);
+  log.appendChild(li);
+  log.scrollTop = log.scrollHeight;
+}
+
+function appendError(command: string, message: string) {
+  const li = document.createElement("li");
+  const cmdLine = document.createElement("div");
+  cmdLine.className = "meta";
+  cmdLine.textContent = `> ${command}`;
+  const err = document.createElement("div");
+  err.className = "result err";
+  err.textContent = `× ${message}`;
+  li.appendChild(cmdLine);
+  li.appendChild(err);
+  log.appendChild(li);
+  log.scrollTop = log.scrollHeight;
+}
+
+function renderTools(generated: ToolSummary[], selectedNames: string[], pickedName: string | null) {
+  while (toolsList.firstChild) toolsList.removeChild(toolsList.firstChild);
+  if (generated.length === 0) {
+    toolsList.classList.add("hidden");
+    toolsEmpty.classList.remove("hidden");
+    toolsCount.textContent = "";
+    return;
+  }
+  toolsEmpty.classList.add("hidden");
+  toolsList.classList.remove("hidden");
+  toolsCount.textContent = `${generated.length} generated · ${selectedNames.length} narrowed${pickedName ? " · 1 picked" : ""}`;
+  const selected = new Set(selectedNames);
+  for (const t of generated) {
+    const li = document.createElement("li");
+    const picked = t.name === pickedName;
+    const isSelected = selected.has(t.name);
+    li.className = "tool-row " + (picked ? "picked" : isSelected ? "selected" : "other");
+    const name = document.createElement("span");
+    name.className = "tool-name mono";
+    name.textContent = t.name;
+    const desc = document.createElement("span");
+    desc.className = "tool-desc muted";
+    desc.textContent = t.description;
+    li.appendChild(name);
+    li.appendChild(desc);
+    toolsList.appendChild(li);
+  }
+}
+
+function renderExamples() {
+  for (const ex of EXAMPLES) {
+    const btn = document.createElement("button");
+    btn.className = "chip";
+    btn.textContent = ex;
+    btn.addEventListener("click", () => {
+      goalInput.value = ex;
+      goalInput.focus();
+    });
+    examplesEl.appendChild(btn);
+  }
+}
+
+loadBtn.addEventListener("click", async () => {
+  loadBtn.disabled = true;
+  loadBtn.textContent = "Loading…";
+  setStatus("loading", "loading model");
+  try {
+    model = await NeedleModel.load((p) => {
+      renderProgress(p);
+      if (p.stage === "engine") setStatus("loading", "initializing engine");
+    });
+    setStatus("ready", "model ready");
+    progressEl.classList.add("hidden");
+    loadBtn.classList.add("hidden");
+    playPanel.classList.remove("hidden");
+    goalInput.focus();
+  } catch (e) {
+    console.error(e);
+    setStatus("error", "load failed");
+    progressLabel.textContent = `Error: ${(e as Error).message}`;
+    loadBtn.disabled = false;
+    loadBtn.textContent = "Retry";
+  }
+});
+
+async function run() {
+  if (!model) return;
+  const command = goalInput.value.trim();
+  if (!command) return;
+
+  runBtn.disabled = true;
+  runBtn.textContent = "Running…";
+  setStatus("running", "thinking");
+
+  // Inference runs in a Web Worker (see src/worker.ts) so the main thread
+  // stays interactive — no setTimeout-yield hack needed.
+  const result = await dispatch(model, editableRoot, command);
+  if (result.type === "step") {
+    appendStep(command, result.step);
+    renderTools(result.step.generated, result.step.selectedNames, result.step.call.name);
+  } else {
+    appendError(command, result.message);
+    if (result.rawModelOutput) console.warn("raw model output:", result.rawModelOutput);
+    if (result.generated) renderTools(result.generated, result.selectedNames ?? [], null);
+  }
+  goalInput.value = "";
+  runBtn.disabled = false;
+  runBtn.textContent = "Run →";
+  setStatus("ready", "model ready");
+  goalInput.focus();
+}
+
+runBtn.addEventListener("click", run);
+goalInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !runBtn.disabled) run();
+});
+
+renderExamples();
+setStatus("idle", "model not loaded");

--- a/examples/dom-editor/src/model.ts
+++ b/examples/dom-editor/src/model.ts
@@ -1,0 +1,110 @@
+// Worker-backed client for the Needle engine.
+//
+// All inference happens off the main thread (see src/worker.ts). This client
+// is a thin postMessage wrapper that hands out promises for each request.
+
+export type LoadProgress = {
+  stage: "init" | "weights" | "vocab" | "engine" | "ready";
+  loadedBytes?: number;
+  totalBytes?: number;
+};
+
+type InMsg =
+  | { id: number; type: "load" }
+  | { id: number; type: "infer"; query: string; toolsJson: string }
+  | { id: number; type: "retrieve"; query: string; descriptions: string[]; topK: number }
+  | { id: number; type: "hasContrastive" };
+
+type OutMsg =
+  | { id: number; type: "progress"; stage: LoadProgress["stage"]; loadedBytes?: number; totalBytes?: number }
+  | { id: number; type: "result"; data: unknown }
+  | { id: number; type: "error"; message: string };
+
+type Pending = {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  onProgress?: (p: LoadProgress) => void;
+};
+
+export class NeedleModel {
+  private worker: Worker;
+  private nextId = 1;
+  private pending = new Map<number, Pending>();
+  private contrastiveAvailable = false;
+
+  private constructor(worker: Worker) {
+    this.worker = worker;
+    this.worker.addEventListener("message", (ev: MessageEvent<OutMsg>) => this.onMessage(ev.data));
+    this.worker.addEventListener("error", (ev) => {
+      // Reject every outstanding request; without this they'd hang forever.
+      const err = new Error(`worker error: ${ev.message}`);
+      for (const p of this.pending.values()) p.reject(err);
+      this.pending.clear();
+    });
+  }
+
+  private onMessage(msg: OutMsg): void {
+    const p = this.pending.get(msg.id);
+    if (!p) return;
+    if (msg.type === "progress") {
+      p.onProgress?.({ stage: msg.stage, loadedBytes: msg.loadedBytes, totalBytes: msg.totalBytes });
+      return; // load isn't done yet
+    }
+    this.pending.delete(msg.id);
+    if (msg.type === "result") p.resolve(msg.data);
+    else p.reject(new Error(msg.message));
+  }
+
+  // Distributive Omit so each variant of the union keeps its narrowed shape.
+  private request<T>(
+    msg: InMsg extends infer U ? (U extends { id: number } ? Omit<U, "id"> : never) : never,
+    onProgress?: (p: LoadProgress) => void,
+  ): Promise<T> {
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: resolve as (v: unknown) => void,
+        reject,
+        onProgress,
+      });
+      this.worker.postMessage({ ...msg, id });
+    });
+  }
+
+  static async load(onProgress: (p: LoadProgress) => void): Promise<NeedleModel> {
+    const worker = new Worker(new URL("./worker.ts", import.meta.url), { type: "module" });
+    const m = new NeedleModel(worker);
+    const meta = await m.request<{ contrastiveDim: number }>({ type: "load" }, onProgress);
+    m.contrastiveAvailable = meta.contrastiveDim > 0;
+    if (m.contrastiveAvailable) {
+      console.info(`[needle-playground] contrastive head present, dim=${meta.contrastiveDim}`);
+    } else {
+      console.warn(
+        "[needle-playground] loaded weights have no contrastive head — " +
+          "retrieve_tools will return empty; falling back to JS term-overlap ranker.",
+      );
+    }
+    return m;
+  }
+
+  hasContrastiveHead(): boolean {
+    return this.contrastiveAvailable;
+  }
+
+  infer(query: string, toolsJson: string): Promise<string> {
+    return this.request<string>({ type: "infer", query, toolsJson });
+  }
+
+  retrieve(
+    query: string,
+    descriptions: string[],
+    topK: number,
+  ): Promise<Array<{ index: number; score: number }>> {
+    return this.request<Array<{ index: number; score: number }>>({
+      type: "retrieve",
+      query,
+      descriptions,
+      topK,
+    });
+  }
+}

--- a/examples/dom-editor/src/style.css
+++ b/examples/dom-editor/src/style.css
@@ -1,0 +1,272 @@
+:root {
+  --bg: #0d1117;
+  --bg-elev: #161b22;
+  --border: #30363d;
+  --text: #e6edf3;
+  --muted: #7d8590;
+  --accent: #ce422b;
+  --accent-hover: #e8633f;
+  --ok: #7ee787;
+  --err: #ff7b72;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.mono { font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace; }
+.muted { color: var(--muted); }
+.hidden { display: none !important; }
+
+#app {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 20px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.brand { display: flex; align-items: center; gap: 10px; }
+.brand h1 { font-size: 16px; margin: 0; font-weight: 600; }
+.logo { color: var(--accent); font-size: 18px; }
+
+.pill {
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  color: var(--muted);
+}
+.pill.ready { color: var(--ok); border-color: rgba(126, 231, 135, 0.4); }
+.pill.loading { color: #ffd33d; border-color: rgba(255, 211, 61, 0.4); }
+.pill.error { color: var(--err); border-color: rgba(255, 123, 114, 0.4); }
+.pill.running { color: var(--accent-hover); border-color: rgba(232, 99, 63, 0.5); }
+
+.panel {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+}
+.panel-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+
+.lede { margin: 0 0 14px; color: var(--text); }
+.lede strong { color: var(--accent-hover); }
+
+button.primary {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+button.primary:hover:not(:disabled) { background: var(--accent-hover); }
+button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.progress { margin-top: 12px; }
+.progress-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+.progress-bar {
+  height: 4px;
+  background: #1f2630;
+  border-radius: 2px;
+  overflow: hidden;
+}
+#progress-fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--accent), var(--accent-hover));
+  transition: width 0.15s ease-out;
+}
+
+.prompt-row { display: flex; gap: 8px; }
+#goal-input {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+}
+#goal-input:focus { outline: none; border-color: var(--accent); }
+
+.examples {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.chip {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.chip:hover { color: var(--text); border-color: var(--accent); }
+
+.log-panel { min-height: 200px; }
+
+.log-section {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+@media (min-width: 880px) {
+  .log-section { grid-template-columns: 1fr 1fr; }
+}
+
+.tools-panel .panel-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+.small { font-size: 11px; }
+.tools-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.tool-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 30%) 1fr;
+  gap: 10px;
+  align-items: baseline;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  background: var(--bg);
+  font-size: 12px;
+}
+.tool-row .tool-name { font-size: 11px; }
+.tool-row .tool-desc { font-size: 11px; }
+.tool-row.other { opacity: 0.55; }
+.tool-row.selected {
+  border-color: rgba(232, 99, 63, 0.35);
+  background: rgba(232, 99, 63, 0.06);
+}
+.tool-row.selected .tool-name { color: var(--accent-hover); }
+.tool-row.picked {
+  border-color: rgba(126, 231, 135, 0.5);
+  background: rgba(126, 231, 135, 0.08);
+}
+.tool-row.picked .tool-name { color: var(--ok); font-weight: 600; }
+.tools-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 10px;
+}
+.tools-legend .dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+.dot-picked { background: var(--ok); }
+.dot-selected { background: var(--accent-hover); }
+.dot-other { background: var(--border); }
+
+/* Default style for boxes the model creates via add_box. */
+.box {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin: 12px 0;
+}
+.log {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+.log li {
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.log .call { color: var(--text); }
+.log .call .tool-name { color: var(--accent-hover); font-weight: 600; }
+.log .result.ok { color: var(--ok); }
+.log .result.err { color: var(--err); }
+.log .meta { color: var(--muted); font-size: 10px; }
+
+.disclaimer {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+.disclaimer ul {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+.disclaimer li + li { margin-top: 4px; }
+.disclaimer strong { color: var(--text); }
+.disclaimer code {
+  font-size: 11px;
+  padding: 1px 4px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 3px;
+}
+
+.footer {
+  font-size: 12px;
+  text-align: center;
+  margin-top: 8px;
+}
+.footer a { color: var(--muted); }
+.footer a:hover { color: var(--text); }

--- a/examples/dom-editor/src/tools.ts
+++ b/examples/dom-editor/src/tools.ts
@@ -1,0 +1,322 @@
+// Dynamic per-element tool generation.
+//
+// On every command we walk the editable root (the whole page, minus anything
+// marked data-no-edit), find "interesting" elements, and emit one tool per
+// (element × action). The tool *name* encodes which element it targets, so
+// the model never has to think about selectors — it just picks a name from
+// the list. The element itself lives in the tool's closure.
+//
+// Why this shape: the Needle model is a small single-turn router. It is good
+// at "given English + a list of clearly-named tools, pick one." It is bad at
+// CSS selectors, abstract schema slots, and history-stuffed prompts. Dynamic
+// tool generation turns the targeting problem into the kind of choice the
+// model is best at.
+
+export type ToolCall = {
+  name: string;
+  arguments: Record<string, unknown>;
+};
+
+export type ToolResult =
+  | { ok: true; summary: string }
+  | { ok: false; error: string };
+
+export type GeneratedTool = {
+  name: string;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, { type: string; description?: string }>;
+    required?: string[];
+  };
+  execute: (args: Record<string, unknown>) => ToolResult;
+};
+
+const BANNED_CSS = /url\s*\(|expression\s*\(|javascript:|@import/i;
+
+function str(args: Record<string, unknown>, key: string): string | null {
+  const v = args[key];
+  return typeof v === "string" ? v : null;
+}
+
+// Keep the color example neutral. Earlier we listed "red, blue, teal, #ff0080"
+// and the model would hallucinate "blue" any time the user didn't name a
+// color — it was reaching for the first example in the schema.
+const COLOR_PARAM = {
+  type: "object" as const,
+  properties: {
+    color: { type: "string", description: "A CSS color name or hex code" },
+  },
+  required: ["color"],
+};
+
+// Anchor the text param with an explicit example. Needle's training favors
+// typed entities (cities, colors, times); a bare "the new text" gives it
+// nothing to grip on, which is why "Change the title to Hello" returned [].
+const TEXT_PARAM = {
+  type: "object" as const,
+  properties: {
+    text: {
+      type: "string",
+      description: "The new text content, e.g. 'Welcome' or 'Hello world'",
+    },
+  },
+  required: ["text"],
+};
+
+// Choose a stable, model-friendly label for an element.
+//   id > class > tag+index
+// Lowercased, snake_cased, deduplicated. We strip generic chrome prefixes
+// like `app_`, `page_`, `stage_` so `#app-title` becomes `title`, not
+// `app_title` — otherwise the user's word "title" doesn't match the label
+// the way the contrastive head needs it to.
+const GENERIC_PREFIXES = ["app_", "page_", "stage_"];
+
+function stripGenericPrefix(s: string): string {
+  for (const p of GENERIC_PREFIXES) {
+    if (s.startsWith(p) && s.length > p.length) return s.slice(p.length);
+  }
+  return s;
+}
+
+function labelFor(el: Element, fallbackIndex: number): string {
+  const slug = (s: string) =>
+    s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  if (el.id) return stripGenericPrefix(slug(el.id));
+  if (el.className && typeof el.className === "string") {
+    const first = el.className.split(/\s+/).find(Boolean);
+    if (first) return `${stripGenericPrefix(slug(first))}_${fallbackIndex}`;
+  }
+  return `${el.tagName.toLowerCase()}_${fallbackIndex}`;
+}
+
+// Pick a human role word for descriptions. This word becomes the primary
+// hook the model uses to match the user's natural-language target — so we
+// pick the word a user is most likely to say. An h1 is "the title", not
+// "the heading"; an h3 inside a card is a subheading; structural tags get
+// real role words instead of "element".
+function roleWord(el: Element): string {
+  const tag = el.tagName.toLowerCase();
+  if (tag === "h1") return "title";
+  if (tag === "h2") return "heading";
+  if (/^h[3-6]$/.test(tag)) return "subheading";
+  if (tag === "button") return "button";
+  if (tag === "p") return "paragraph";
+  if (tag === "a") return "link";
+  if (tag === "ul" || tag === "ol") return "list";
+  if (tag === "li") return "list item";
+  if (tag === "img") return "image";
+  if (tag === "footer") return "footer";
+  if (tag === "header") return "header";
+  if (tag === "nav") return "navigation bar";
+  if (tag === "section") return "section";
+  if (tag === "article") return "article";
+  if (tag === "aside") return "sidebar";
+  return "element";
+}
+
+// Truncate text for a description so the schema doesn't blow up. Critically,
+// we skip data-no-edit subtrees — otherwise an editable parent that *contains*
+// non-editable UI (chips, status pills, run buttons) gets a textContent
+// polluted by all that chrome and the ranker latches onto it.
+function visibleText(el: Element): string {
+  let acc = "";
+  for (const child of Array.from(el.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      acc += child.textContent || "";
+    } else if (child.nodeType === Node.ELEMENT_NODE) {
+      const childEl = child as Element;
+      if (childEl.hasAttribute && childEl.hasAttribute("data-no-edit")) continue;
+      acc += visibleText(childEl);
+    }
+  }
+  return acc;
+}
+
+function textPreview(el: Element, max = 40): string {
+  const t = visibleText(el).trim().replace(/\s+/g, " ");
+  if (!t) return "";
+  return t.length > max ? `"${t.slice(0, max)}…"` : `"${t}"`;
+}
+
+// Opt-out: any element marked data-no-edit (or living inside one) is hidden
+// from the model. Used for the prompt input and the step log — we don't want
+// the model wiping the user's command or scrambling its own activity feed.
+function isOptedOut(el: Element): boolean {
+  return el.closest("[data-no-edit]") !== null;
+}
+
+// Tags that are page-root containers, never discrete targets. Exposing them
+// gives the model a tool that matches *any* query (its text preview contains
+// the whole page) and drowns out the specific element tools.
+const ROOT_CONTAINER_TAGS = new Set(["main", "body", "html"]);
+
+// Decide whether an element is "interesting" enough to expose. We skip
+// structural wrappers without identity to keep the tool list small, and
+// skip user-input fields so the model can't wipe what someone's typing.
+function isInteresting(el: Element): boolean {
+  const tag = el.tagName.toLowerCase();
+  if (ROOT_CONTAINER_TAGS.has(tag)) return false;
+  if (["input", "textarea", "select", "script", "style", "link", "meta"].includes(tag)) return false;
+  if (el.id) return true;
+  if (el.className && typeof el.className === "string" && el.className.trim()) return true;
+  if (/^h[1-6]$/.test(tag)) return true;
+  if (["button", "a", "li", "img"].includes(tag)) return true;
+  return false;
+}
+
+export type GenerateResult = {
+  tools: GeneratedTool[];
+  // For UI display: a flat list of (label, role, preview) for each surfaced element.
+  inventory: Array<{ label: string; role: string; preview: string }>;
+};
+
+const MAX_ELEMENTS = 20;
+
+export function generateTools(root: HTMLElement): GenerateResult {
+  const elements: Array<{ el: HTMLElement; label: string; role: string; preview: string }> = [];
+  const usedLabels = new Set<string>();
+  let i = 0;
+
+  for (const el of Array.from(root.querySelectorAll<HTMLElement>("*"))) {
+    if (isOptedOut(el)) continue;
+    if (!isInteresting(el)) continue;
+    let label = labelFor(el, i);
+    let n = 1;
+    let unique = label;
+    while (usedLabels.has(unique)) {
+      n++;
+      unique = `${label}_${n}`;
+    }
+    usedLabels.add(unique);
+    elements.push({ el, label: unique, role: roleWord(el), preview: textPreview(el) });
+    i++;
+    if (elements.length >= MAX_ELEMENTS) break;
+  }
+
+  const tools: GeneratedTool[] = [];
+
+  for (const { el, label, role } of elements) {
+    // Tight, conventional descriptions. Needle was trained on routine routing
+    // ("get weather", "book flight"); unusual verbs like "rewrite" cause it
+    // to return [] instead of guessing. Stick to "Set the X of the Y" — the
+    // model parses that shape reliably.
+    //
+    // We deliberately do NOT include the element's text preview here. With
+    // 3 tools per element having near-identical descriptions, the preview
+    // dominated everything and the model couldn't discriminate between
+    // color/background/text. The action word ("color", "background", "text")
+    // is the discriminator and needs to stand alone.
+    tools.push({
+      name: `set_${label}_color`,
+      description: `Set the color of the ${role}.`,
+      parameters: COLOR_PARAM,
+      execute: (args) => {
+        const color = str(args, "color");
+        if (!color) return { ok: false, error: "color required" };
+        if (BANNED_CSS.test(color)) return { ok: false, error: "color rejected" };
+        el.style.setProperty("color", color);
+        return { ok: true, summary: `${label}.color = ${color}` };
+      },
+    });
+
+    tools.push({
+      name: `set_${label}_background`,
+      description: `Set the background of the ${role}.`,
+      parameters: COLOR_PARAM,
+      execute: (args) => {
+        const color = str(args, "color");
+        if (!color) return { ok: false, error: "color required" };
+        if (BANNED_CSS.test(color)) return { ok: false, error: "color rejected" };
+        el.style.setProperty("background-color", color);
+        return { ok: true, summary: `${label}.background = ${color}` };
+      },
+    });
+
+    tools.push({
+      name: `set_${label}_text`,
+      description: `Set, change, or replace the text of the ${role}.`,
+      parameters: TEXT_PARAM,
+      execute: (args) => {
+        const text = str(args, "text");
+        if (text === null) return { ok: false, error: "text required" };
+        el.textContent = text;
+        return { ok: true, summary: `${label}.text = "${text}"` };
+      },
+    });
+  }
+
+  // Stage-level tools that don't target a specific element.
+  tools.push({
+    name: "add_paragraph",
+    description: "Append a new paragraph of text to the page.",
+    parameters: TEXT_PARAM,
+    execute: (args) => {
+      const text = str(args, "text");
+      if (text === null) return { ok: false, error: "text required" };
+      const p = document.createElement("p");
+      p.textContent = text;
+      root.appendChild(p);
+      return { ok: true, summary: `+ <p>"${text}"</p>` };
+    },
+  });
+
+  tools.push({
+    name: "add_button",
+    description: "Append a new button to the page.",
+    parameters: TEXT_PARAM,
+    execute: (args) => {
+      const text = str(args, "text");
+      if (text === null) return { ok: false, error: "text required" };
+      const b = document.createElement("button");
+      b.textContent = text;
+      root.appendChild(b);
+      return { ok: true, summary: `+ <button>"${text}"</button>` };
+    },
+  });
+
+  tools.push({
+    name: "add_box",
+    description: "Append a new box (a styled container) to the page.",
+    parameters: {
+      type: "object",
+      properties: {
+        text: { type: "string", description: "Optional text content for the box, e.g. 'A new box'" },
+      },
+    },
+    execute: (args) => {
+      const text = str(args, "text") || "";
+      const div = document.createElement("div");
+      div.className = "box";
+      if (text) div.textContent = text;
+      root.appendChild(div);
+      return { ok: true, summary: text ? `+ <div.box>"${text}"</div>` : "+ <div.box>" };
+    },
+  });
+
+  tools.push({
+    name: "add_heading",
+    description: "Append a new heading to the page.",
+    parameters: TEXT_PARAM,
+    execute: (args) => {
+      const text = str(args, "text");
+      if (text === null) return { ok: false, error: "text required" };
+      const h = document.createElement("h2");
+      h.textContent = text;
+      root.appendChild(h);
+      return { ok: true, summary: `+ <h2>"${text}"</h2>` };
+    },
+  });
+
+  return {
+    tools,
+    inventory: elements.map(({ label, role, preview }) => ({ label, role, preview })),
+  };
+}
+
+// Build the OpenAI-style schema string for a given subset of tools.
+export function toolsSchemaJson(tools: GeneratedTool[]): string {
+  return JSON.stringify(
+    tools.map(({ name, description, parameters }) => ({ name, description, parameters })),
+  );
+}

--- a/examples/dom-editor/src/worker.ts
+++ b/examples/dom-editor/src/worker.ts
@@ -1,0 +1,116 @@
+// Web Worker that owns the NeedleWasm engine.
+//
+// The engine's `run()` is a synchronous, multi-second wasm call. Running it
+// on the main thread freezes the UI (no animation, no input, no scroll).
+// Moving it here means the main thread is only blocked when serializing
+// arguments and deserializing the result — milliseconds, not seconds.
+//
+// The DOM walker, tool execution, and UI all stay on the main thread; this
+// worker only knows about the model.
+
+import init, { NeedleWasm } from "needle-rs";
+
+const HF_BASE = "https://huggingface.co/Abdalrahman/needle-rs-safetensors/resolve/main";
+const WEIGHTS_URL = `${HF_BASE}/needle.safetensors`;
+const VOCAB_URL = `${HF_BASE}/vocab.txt`;
+
+type LoadStage = "init" | "weights" | "vocab" | "engine" | "ready";
+
+type InMsg =
+  | { id: number; type: "load" }
+  | { id: number; type: "infer"; query: string; toolsJson: string }
+  | { id: number; type: "retrieve"; query: string; descriptions: string[]; topK: number }
+  | { id: number; type: "hasContrastive" };
+
+type OutMsg =
+  | { id: number; type: "progress"; stage: LoadStage; loadedBytes?: number; totalBytes?: number }
+  | { id: number; type: "result"; data: unknown }
+  | { id: number; type: "error"; message: string };
+
+let engine: NeedleWasm | null = null;
+
+function post(msg: OutMsg): void {
+  (self as unknown as Worker).postMessage(msg);
+}
+
+async function fetchWithProgress(
+  url: string,
+  hintBytes: number,
+  id: number,
+  stage: LoadStage,
+): Promise<Uint8Array> {
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`fetch ${url} → ${resp.status}`);
+  const total = parseInt(resp.headers.get("content-length") || "0") || hintBytes;
+  const reader = resp.body!.getReader();
+  const chunks: Uint8Array[] = [];
+  let loaded = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    loaded += value.length;
+    post({ id, type: "progress", stage, loadedBytes: loaded, totalBytes: total });
+  }
+  const buf = new Uint8Array(loaded);
+  let off = 0;
+  for (const c of chunks) {
+    buf.set(c, off);
+    off += c.length;
+  }
+  return buf;
+}
+
+async function handleLoad(id: number): Promise<void> {
+  post({ id, type: "progress", stage: "init" });
+  await init();
+
+  const weights = await fetchWithProgress(WEIGHTS_URL, 22 * 1024 * 1024, id, "weights");
+
+  const vocabBytes = await fetchWithProgress(VOCAB_URL, 120 * 1024, id, "vocab");
+  const vocab = new TextDecoder().decode(vocabBytes);
+
+  post({ id, type: "progress", stage: "engine" });
+  const e = NeedleWasm.load(weights, vocab);
+  if (!e) throw new Error("NeedleWasm.load returned undefined");
+  engine = e;
+
+  post({ id, type: "progress", stage: "ready" });
+  post({ id, type: "result", data: { contrastiveDim: e.contrastive_dim() } });
+}
+
+self.addEventListener("message", async (ev: MessageEvent<InMsg>) => {
+  const msg = ev.data;
+  try {
+    switch (msg.type) {
+      case "load":
+        await handleLoad(msg.id);
+        return;
+      case "infer": {
+        if (!engine) throw new Error("model not loaded");
+        const result = engine.run(msg.query, msg.toolsJson);
+        post({ id: msg.id, type: "result", data: result });
+        return;
+      }
+      case "retrieve": {
+        if (!engine) throw new Error("model not loaded");
+        const raw = engine.retrieve_tools(msg.query, JSON.stringify(msg.descriptions), msg.topK);
+        let parsed: Array<{ index: number; score: number }> = [];
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          /* leave empty */
+        }
+        post({ id: msg.id, type: "result", data: parsed });
+        return;
+      }
+      case "hasContrastive": {
+        if (!engine) throw new Error("model not loaded");
+        post({ id: msg.id, type: "result", data: engine.contrastive_dim() > 0 });
+        return;
+      }
+    }
+  } catch (e) {
+    post({ id: msg.id, type: "error", message: (e as Error).message });
+  }
+});

--- a/examples/dom-editor/tsconfig.json
+++ b/examples/dom-editor/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "esnext",
+    "lib": ["ES2023", "DOM"],
+    "types": ["vite/client"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What does this PR do?

A real-life use case for needle-rs: a 22 MB tool-calling LLM that rewrites a live web page from plain-English commands, entirely in the browser. Tools are generated fresh on every command from the current DOM (one per element x action), narrowed with the contrastive head, then routed by the engine to a single tool call that runs against the page.

## Motivation

`examples/browser-demo` shows the engine running in a browser against a *static* tool list — useful for verifying the runtime works, but it doesn't demonstrate how anyone would actually wire needle-rs into an app whose tool surface depends on live state.

This example fills that gap with a real use case: a page editor where the LLM rewrites the DOM from plain-English commands. Tools are generated fresh on every command from whatever is on the page, so adding/removing elements in one turn reshapes the tool list for the next. It exercises the parts of needle-rs that the static demo doesn't — `retrieve_tools` (contrastive narrowing), running the engine in a Web Worker, and packaging the published `needle-rs` npm package into a Vite app

## Changes
- New `examples/dom-editor/` directory: standalone Vite + TypeScript app that pulls `needle-rs` from npm — no local Rust toolchain required.
- `src/tools.ts` — DOM walker that emits one tool per (element × action). Tool names encode their target (`set_title_color`, `set_lede_background`); elements are held in closures, so the model never sees a selector. Honors `data-no-edit` to keep the model out of its own UI chrome.
- `src/harness.ts` — two-stage pipeline: `retrieve_tools` narrows to top-K (with a JS term-overlap fallback when the loaded weights have no contrastive head), then `run` routes to one tool with arguments filled in.
- `src/worker.ts` + `src/model.ts` — engine runs in a Web Worker so the multi-second WASM `run()` doesn't freeze the UI; `postMessage` client on the main thread.
- `src/main.ts` + `index.html` + `src/style.css` — UI with prompt, step log (retrieve / infer timings, candidate counts), a panel listing every generated tool with top-K / picked highlighting, and a Limitations notice describing what the 26M-param model can and can't do.
- `README.md` — explains the pipeline, why dynamic tool generation matches what Needle is good at, and pointers to the design decisions worth reading the source for.


## Parity / correctness

- [x] I ran `cargo test --workspace` and all tests pass
- [x] If this touches inference logic: I verified numerical parity with the Python reference
      (or added a test to `crates/needle-infer/tests/` that covers it)

## Checklist

- [x] `cargo fmt --all` applied
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] No new panics in hot path (`unwrap`/`expect` only in tests or one-time init)
- [x] Public API changes are doc-commented
